### PR TITLE
A few changes to get this to work on my machine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 Place script wherever you like, then edit first line to include any networks you would like to mark as "safe" so that bluetooth remains turned on even when no devices are connected. 
 
-Edit crontab file with `crontab -e` and add line `* * * * * /full path to script/bluetooth_check.sh`
+Edit crontab file with `crontab -e` and add line `* * * * * /*full path to script*/bluetooth_check.sh >> /tmp/bt.log 2 >> tmp/bt.log `
+
+Logs will be written to `/tmp/bt.log`. It'd be more conventional to write to `/var/log`, but then
+we'd have to get permissions right.
 
 If you are running MacOS 12+ you will also likely need to give full disk access to cron by going to Apple Icon > System Preferences > Security and Privacy > Privacy > Full Disk Access > Click the lock to unlock > Click + > Hold Cmd + Shift + G to bring up path navigation and type in /usr/sbin/cron and hit enter > Click Open > Click the Checkbox next to cron to enable
 

--- a/bluetooth_check.sh
+++ b/bluetooth_check.sh
@@ -1,14 +1,52 @@
 #!/bin/bash
 
-# - Enter exempted work SSIDs here, separated by spaces - #
+# Fail on errors: https://wizardzines.com/comics/bash-errors/
+set -e
 
+# Find the blueutil binary in a few common locations
+blueutil=""
+bins=("/opt/homebrew/bin" "/usr/local/bin")
+for p in ${bins[@]}; do
+    bp="$p/blueutil"
+    if [[ -x "$bp" ]]; then
+        blueutil=$bp
+        break
+    fi
+done
+
+# If we couldn't find it, fail fast.
+if [[ -z "$blueutil" ]]; then
+    echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] error: blueutil not installed"
+    exit 1
+fi
+
+# If bluetooth is already enabled, we don't need to do anything
+if [[ $($blueutil -p) == 1 ]]; then
+    echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] Bluetooth already enabled"
+    exit 0
+fi
+
+# - Enter trusted SSIDs here, separated by spaces - #
 workSSID=("ai2 Team" "ai2 guest")
 
 currentSSID=$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | awk -F' SSID: '  '/ SSID: / {print $2}')
 
-for i in ${!workSSID[@]};
-do
-	if [ $(/opt/homebrew/bin/blueutil -p) == 0 ] && [[ ${workSSID[$i]} == $currentSSID ]]; then
-		/opt/homebrew/bin/blueutil -p 1
+# Determine if the current SSID is trusted.
+trusted=false
+for i in ${!workSSID[@]}; do
+    ssid=${workSSID[$i]}
+	if [[ "$ssid" == "$currentSSID" ]]; then
+        trusted=true
+        break
 	fi
 done
+
+# Fail fast if it's not
+if [[ $trusted == false ]]; then
+    echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] $currentSSID is not trusted"
+    exit 0
+fi
+
+# It is, enable bluetooth!
+$blueutil -p 1
+echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] Bluetooth enabled"


### PR DESCRIPTION
Initially this didn't work on my machine, as HomeBrew in my case
installs things into `/usr/local`, not `/opt`. So I added a little
code to search both `/opt` and `/usr/local`, which might make things
more portable.

While doing this I made a few other small changes:

- The script will now fail if it encounters an error
- I modified the `crontab` entry so that the script's logs will go
  somewhere
- I reworked things a bit while debugging things